### PR TITLE
色々修正やリファクタ

### DIFF
--- a/source/app/src/main/java/azz/anythingmanagement/DataListActivity.java
+++ b/source/app/src/main/java/azz/anythingmanagement/DataListActivity.java
@@ -37,7 +37,7 @@ import azz.anythingmanagement.xmlData.RegistData;
  * @author c.morita
  * @version 1.0
  */
-public class DataListActivity extends AppCompatActivity {
+public class DataListActivity extends AppCompatActivity implements View.OnClickListener {
 
     // Mapのキー
     private final String[] FROM = {"dataIndex", "dataTitle", "isDataReading"};
@@ -123,6 +123,22 @@ public class DataListActivity extends AppCompatActivity {
                 return true;
             }
         });
+    }
+
+    @Override
+    public void onClick(View v) {
+        //String dataGenreName = regDataMapList.get(position).get("dataGenre").toString();
+        // TODO::ここでジャンルを取得する想定
+        Intent intent;
+        int id = v.getId();
+        // 詳細登録画面へ遷移する
+        if (id == R.id.data_insert_button) {
+            intent = new Intent(this, DataRegistDetailActivity.class);
+            intent.putExtra("mode", common.MODE_REGIST);
+            intent.putExtra("genre", "未選択");
+            finish();
+            startActivity(intent);
+        }
     }
 
     @Override

--- a/source/app/src/main/java/azz/anythingmanagement/GenreIns.java
+++ b/source/app/src/main/java/azz/anythingmanagement/GenreIns.java
@@ -92,6 +92,7 @@ public class GenreIns extends AppCompatActivity {
                 tv.setTextColor(Color.WHITE);
 
                 // 登録後はジャンル一覧画面に遷移
+                finish();
                 startActivity(intent);
             }
         });

--- a/source/app/src/main/java/azz/anythingmanagement/GenreListActivity.java
+++ b/source/app/src/main/java/azz/anythingmanagement/GenreListActivity.java
@@ -20,6 +20,7 @@ public class GenreListActivity extends AppCompatActivity implements View.OnClick
 
     private Data data;
     private Context context;
+    private int button_count = 8;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -51,15 +52,16 @@ public class GenreListActivity extends AppCompatActivity implements View.OnClick
 
         // 動的にボタンを生成しているように設定する
         for (int i = 0; i < genreList.size(); i++) {
-            // 9ボタン以上は設定しない(暫定対応)
-            if(i == 9)
-            {
+
+            // button生成時の上限設定
+            int y = i + 1;
+            if(y > button_count) {
                 return;
             }
 
             Button btn;
-            int y = i + 1;
             btn = findViewById(R.id.genruList_botton + y);
+            System.out.print(btn);
             // ボタンの非透明化
             btn.setVisibility(View.VISIBLE);
             final String genrename = String.valueOf(genreList.get(i).getGenreName());
@@ -99,7 +101,6 @@ public class GenreListActivity extends AppCompatActivity implements View.OnClick
                     finish();
                     Intent intent = new Intent(getApplication(), GenreListActivity.class);
                     startActivity(intent);
-
                     return true;
                 }
             });
@@ -108,13 +109,21 @@ public class GenreListActivity extends AppCompatActivity implements View.OnClick
 
     @Override
     public void onClick(View v) {
-        // 各ボタンアクションで使用するintentをここで呼んでおく
-        Intent intent;
-        int id = v.getId();
-        // ジャンル登録画面へ遷移する
-        if(id == R.id.insert_button) {
-            intent = new Intent(this, GenreIns.class);
-            startActivity(intent);
+        // ジャンル一覧を取得
+        data = new Data();
+        ArrayList<Genre> genreList = data.getGenreList(context);
+        // 9件以上登録され無いようにする（暫定対応）
+        if(genreList.size() < button_count) {
+            // 各ボタンアクションで使用するintentをここで呼んでおく
+            Intent intent;
+            int id = v.getId();
+            // ジャンル登録画面へ遷移する
+            if (id == R.id.insert_button) {
+                intent = new Intent(this, GenreIns.class);
+                startActivity(intent);
+            }
+        }else{
+            return;
         }
     }
 

--- a/source/app/src/main/res/layout/datalist.xml
+++ b/source/app/src/main/res/layout/datalist.xml
@@ -19,9 +19,27 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.0" />
 
+    <Button
+        android:id="@+id/data_insert_button"
+        android:layout_width="341dp"
+        android:layout_height="85dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:text="@string/tempregistName"
+        android:textSize="25sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.502"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout2"
+        app:layout_constraintVertical_bias="1.0" />
+
     <LinearLayout
+        android:id="@+id/linearLayout2"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="781dp"
         android:orientation="vertical">
 
         <TextView

--- a/source/app/src/main/res/layout/genrelist.xml
+++ b/source/app/src/main/res/layout/genrelist.xml
@@ -53,7 +53,7 @@
             app:layout_row="0" />
 
         <Button
-            android:id="@+id/genruList_botton2"
+            android:id="@+id/genruList_botton1"
             android:layout_width="185dp"
             android:layout_height="185dp"
             android:layout_marginStart="16dp"
@@ -69,7 +69,7 @@
             app:layout_row="0" />
 
         <Button
-            android:id="@+id/genruList_botton3"
+            android:id="@+id/genruList_botton2"
             android:layout_width="185dp"
             android:layout_height="185dp"
             android:layout_marginStart="16dp"
@@ -85,7 +85,7 @@
             app:layout_row="0" />
 
         <Button
-            android:id="@+id/genruList_botton4"
+            android:id="@+id/genruList_botton3"
             android:layout_width="185dp"
             android:layout_height="185dp"
             android:layout_marginStart="16dp"
@@ -102,7 +102,7 @@
             app:layout_row="1" />
 
         <Button
-            android:id="@+id/genruList_botton5"
+            android:id="@+id/genruList_botton4"
             android:layout_width="185dp"
             android:layout_height="185dp"
             android:layout_marginStart="16dp"
@@ -118,7 +118,7 @@
             app:layout_row="1" />
 
         <Button
-            android:id="@+id/genruList_botton6"
+            android:id="@+id/genruList_botton5"
             android:layout_width="185dp"
             android:layout_height="185dp"
             android:layout_marginStart="16dp"
@@ -134,7 +134,7 @@
             app:layout_row="1" />
 
         <Button
-            android:id="@+id/genruList_botton7"
+            android:id="@+id/genruList_botton6"
             android:layout_width="185dp"
             android:layout_height="185dp"
             android:layout_marginStart="16dp"
@@ -150,7 +150,7 @@
             app:layout_row="2" />
 
         <Button
-            android:id="@+id/genruList_botton8"
+            android:id="@+id/genruList_botton7"
             android:layout_width="185dp"
             android:layout_height="185dp"
             android:layout_marginStart="16dp"
@@ -166,7 +166,7 @@
             app:layout_row="2" />
 
         <Button
-            android:id="@+id/genruList_botton9"
+            android:id="@+id/genruList_botton8"
             android:layout_width="185dp"
             android:layout_height="185dp"
             android:layout_marginStart="16dp"


### PR DESCRIPTION
◆緊急(最優先)
- [x] ジャンル選択画面のボタンが生成後黒くなってしまう

◆ジャンル一覧画面の残作業（優先度：高）
- [x] ジャンル作成によるボタン増幅
- [x] 長押しによるボタンの削除
- [x] ボタンの削除時一緒にDBも削除
- [x] DBからの呼び出し
- [x] ジャンルボタン押下後の画面遷移
- [x] データ一覧画面への遷移時に渡すデータの確認
- [x] ジャンルボタン生成上限の設定
- [ ] ~~スクロールできるようにする~~

◆ヘッダメニューの動作に関する残作業（優先度：低）
- [ ] メニューから遷移後の画面の動線確認

◆ジャンル登録画面の残作業（優先度：中）
- [x] 確認用ラベルの削除
- [x] ボタン強調は時間がないので、選択したカラーを文字の上で表示するようにする
- [x] 表示後に文字が出るのでそれの削除
- [x] 登録後にジャンル一覧に遷移させる
- [x] 全体的なレイアウトの見直し
- [ ] DB登録時の順序関連

◆データ一覧画面の残作業（優先度：高）
- [ ] データ一覧画面への遷移周りの確認
- [ ] データ一覧画面に登録ボタン作成

◆その他懸念事項等（優先度：低）
- [ ] 戻るボタンがないことでのユーザビリティの悪さ
- [ ] クレジット画面の作成
- [ ] 起動時の画面があったほうがいいかも